### PR TITLE
ops(probe): version systemd probe + logrotate + installer (no secrets)

### DIFF
--- a/ops/probe/README.md
+++ b/ops/probe/README.md
@@ -1,0 +1,12 @@
+# Election Probe (systemd)
+Files:
+- probe_election_current.sh -> /usr/local/bin/
+- election-probe.service    -> /etc/systemd/system/
+- election-probe.timer      -> /etc/systemd/system/
+- papsas-probe.logrotate    -> /etc/logrotate.d/
+- hardening.conf (optional) -> /etc/systemd/system/election-probe.service.d/
+
+Install:
+  ./ops/probe/install.sh
+Then create /etc/papsas/probe.env from ops/probe/probe.env.example and start:
+  sudo systemctl start election-probe.service

--- a/ops/probe/election-probe.service
+++ b/ops/probe/election-probe.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Probe current election endpoints
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=papsas
+Group=papsas
+EnvironmentFile=-/etc/papsas/probe.env
+RuntimeDirectory=papsas
+RuntimeDirectoryMode=0750
+StandardOutput=append:/var/log/papsas/probe.log
+StandardError=append:/var/log/papsas/probe.log
+ExecStart=/usr/local/bin/probe_election_current.sh
+NoNewPrivileges=true
+PrivateTmp=true

--- a/ops/probe/election-probe.timer
+++ b/ops/probe/election-probe.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Every 5 minutes, probe current election
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=election-probe.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ops/probe/hardening.conf
+++ b/ops/probe/hardening.conf
@@ -1,0 +1,6 @@
+[Service]
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+RestrictAddressFamilies=AF_INET AF_INET6
+TimeoutStartSec=30s

--- a/ops/probe/install.sh
+++ b/ops/probe/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+sudo install -m 0755 "$SCRIPT_DIR/probe_election_current.sh" /usr/local/bin/probe_election_current.sh
+sudo install -m 0644 "$SCRIPT_DIR/election-probe.service"    /etc/systemd/system/election-probe.service
+sudo install -m 0644 "$SCRIPT_DIR/election-probe.timer"      /etc/systemd/system/election-probe.timer
+sudo install -d -m 0755 /etc/systemd/system/election-probe.service.d || true
+if [ -f "$SCRIPT_DIR/hardening.conf" ]; then
+  sudo install -m 0644 "$SCRIPT_DIR/hardening.conf" /etc/systemd/system/election-probe.service.d/hardening.conf
+fi
+sudo install -d -o papsas -g papsas -m 0750 /var/log/papsas
+sudo install -d -o papsas -g papsas -m 0750 /run/papsas || true
+sudo install -m 0644 "$SCRIPT_DIR/papsas-probe.logrotate" /etc/logrotate.d/papsas-probe
+sudo systemctl daemon-reload
+sudo systemctl enable --now election-probe.timer
+echo "Copy ops/probe/probe.env.example to /etc/papsas/probe.env and fill secrets, then: sudo systemctl start election-probe.service"

--- a/ops/probe/papsas-probe.logrotate
+++ b/ops/probe/papsas-probe.logrotate
@@ -1,0 +1,9 @@
+/var/log/papsas/probe.log {
+  weekly
+  rotate 8
+  compress
+  missingok
+  notifempty
+  copytruncate
+  create 0640 papsas papsas
+}

--- a/ops/probe/probe.env.example
+++ b/ops/probe/probe.env.example
@@ -1,0 +1,3 @@
+API=https://api.papsasinc.com/api
+PROBE_USER=officer
+PROBE_PASS=REPLACE_ME

--- a/ops/probe/probe_election_current.sh
+++ b/ops/probe/probe_election_current.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+API="${API:-https://api.papsasinc.com/api}"
+RUNDIR="${RUNTIME_DIRECTORY:-/run/papsas}"
+TOKEN_FILE="$RUNDIR/probe.token"
+LAST_USER_FILE="$RUNDIR/.last_user"
+
+log(){ printf '%s %s\n' "$(date '+%F %T')" "$*" >&2; }
+
+mkdir -p "$RUNDIR" 2>/dev/null || true
+
+# Auto cache-bust if PROBE_USER changed
+CUR_USER="${PROBE_USER:-}"
+PREV_USER="$(cat "$LAST_USER_FILE" 2>/dev/null || true)"
+if [[ "${CUR_USER:-}" != "${PREV_USER:-}" ]]; then
+  rm -f "$TOKEN_FILE"
+  umask 077; printf '%s' "$CUR_USER" > "$LAST_USER_FILE"
+fi
+
+get_token(){
+  if [[ -n "${ADMIN:-}" ]]; then printf '%s' "$ADMIN"; return 0; fi
+  if [[ -f "$TOKEN_FILE" ]]; then
+    local T; T="$(cat "$TOKEN_FILE")"
+    if curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $T" "$API/health" | grep -qE '^(200|204)$'; then
+      printf '%s' "$T"; return 0
+    fi
+  fi
+  if [[ -n "${PROBE_USER:-}" && -n "${PROBE_PASS:-}" ]]; then
+    local JCODE T
+    JCODE=$(curl -sS -o "$RUNDIR/login.json" -w '%{http_code}' \
+      -H 'Content-Type: application/json' \
+      -d "{\"username\":\"$PROBE_USER\",\"password\":\"$PROBE_PASS\"}" \
+      "$API/auth/login" || true)
+    T="$(python3 - <<'PY' "$RUNDIR/login.json" || true
+import sys, json, pathlib
+p=pathlib.Path(sys.argv[1])
+try:
+  d=json.loads(p.read_text()); print(d.get("access",""))
+except Exception:
+  print("")
+PY
+)"
+    log "login -> ${JCODE} token_len=${#T}"
+    if [[ -n "$T" ]]; then umask 077; printf '%s' "$T" > "$TOKEN_FILE"; printf '%s' "$T"; return 0; fi
+  fi
+  printf ''
+}
+
+TOKEN="$(get_token || true)"; AUTH=(); [[ -n "$TOKEN" ]] && AUTH=(-H "Authorization: Bearer $TOKEN")
+
+set +o pipefail
+CODE="$(curl -sS -H 'Accept: application/json' "${AUTH[@]}" -w '%{http_code}' -o "$RUNDIR/current.json" "$API/elections/current" || true)"
+set -o pipefail
+log "/elections/current -> $CODE (saved: $RUNDIR/current.json)"
+
+EID="$(python3 - <<'PY' "$RUNDIR/current.json" || true
+import sys, json, pathlib
+p=pathlib.Path(sys.argv[1])
+try:
+  d=json.loads(p.read_text())
+  print((d[0]["id"] if isinstance(d, list) and d else d.get("id") or ""))
+except Exception:
+  print("")
+PY
+)"
+if [[ -z "$EID" ]]; then log "WARN: could not resolve election id (continuing)"; exit 0; fi
+
+probe(){ local path="$1"; local code; code="$(curl -sS -o /dev/null -w '%{http_code}' "${AUTH[@]}" "$API$path" || true)"; log "$path -> $code"; }
+
+probe "/elections/$EID/positions"
+probe "/elections/$EID/ballot"
+probe "/elections/$EID/candidacies"
+probe "/elections/$EID/results"
+log "done eid=$EID"


### PR DESCRIPTION
## What
Adds a production-ready systemd probe for election endpoints with:
- oneshot service + 5-min timer
- hardened unit drop-in (optional)
- logrotate policy
- idempotent installer
- env example (no secrets)
- officer/admin token login with cache + user-change busting

## Files
- ops/probe/probe_election_current.sh
- ops/probe/election-probe.service
- ops/probe/election-probe.timer
- ops/probe/papsas-probe.logrotate
- ops/probe/hardening.conf
- ops/probe/probe.env.example
- ops/probe/install.sh
- ops/probe/README.md

## Deploy (as root-capable user on server)
```bash
cd /srv/papsas/app
git fetch && git checkout ops/probe-service-20251112
sudo ./ops/probe/install.sh
# then create and fill: /etc/papsas/probe.env (from .example)
sudo systemctl start election-probe.service
sudo systemctl enable --now election-probe.timer
